### PR TITLE
Feature/sleep mode

### DIFF
--- a/src/PlanningPoker.Client/Pages/Session/Session.razor
+++ b/src/PlanningPoker.Client/Pages/Session/Session.razor
@@ -63,6 +63,8 @@
 
     private string? _username;
 
+    private Guid _recoveryId = Guid.NewGuid();
+
     private PlayerType _type = PlayerType.Participant;
 
     private PlayerViewModel? _currentPlayer;
@@ -87,7 +89,7 @@
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (!firstRender) return;
-
+        
         await ReconnectIfApplicable();
     }
 
@@ -142,6 +144,7 @@
         {
             _username = savedSession.Username;
             _type = savedSession.Type;
+            _recoveryId = savedSession.RecoveryId;
             await Join();
             StateHasChanged();
         }
@@ -150,11 +153,12 @@
     async Task Join()
     {
         await _hubClient.Connect(_parsedId);
-        _currentPlayer = await _hubClient.JoinServer(_parsedId, _username, _type);
+        _currentPlayer = await _hubClient.JoinServer(_parsedId, _recoveryId, _username, _type);
         var serverSession = new ServerSession
         {
             ServerId = _parsedId,
             Username = _username,
+            RecoveryId = _recoveryId,
             Type = _type
         };
 

--- a/src/PlanningPoker.Client/Pages/Session/_sessionRenderingComponent.razor
+++ b/src/PlanningPoker.Client/Pages/Session/_sessionRenderingComponent.razor
@@ -16,14 +16,14 @@
                     </tr>
                 </thead>
                 <tbody>
-                @foreach (var player in Server?.Players?.Where(p => p.Type == PlayerType.Participant) ?? Enumerable.Empty<PlayerViewModel>())
+                @foreach (var player in Server?.Players?.Where(p => p.Type == PlayerType.Participant).OrderBy(p => p.PublicId) ?? Enumerable.Empty<PlayerViewModel>())
                 {
                     var hasVoted = Server?.CurrentSession?.Votes?.ContainsKey(player.PublicId.ToString()) ?? false;
                     var isAsleep = player.Mode == PlayerMode.Asleep;
                     var currentPlayerVote = hasVoted ? Server.CurrentSession.Votes[player.PublicId.ToString()] : string.Empty;
                     <tr class="@(hasVoted ? "table-success" : "") @(isAsleep ? "asleep" : "")">
                         <td>
-                            @if (hasVoted)
+                            @if (hasVoted && !isAsleep)
                             {
                                 <span class="oi oi-check"></span>
                             }
@@ -72,9 +72,10 @@
                     </tr>
                 </thead>
                 <tbody>
-                @foreach (var player in Server?.Players?.Where(p => p.Type == PlayerType.Observer) ?? Enumerable.Empty<PlayerViewModel>())
+                @foreach (var player in Server?.Players?.Where(p => p.Type == PlayerType.Observer).OrderBy(p => p.PublicId) ?? Enumerable.Empty<PlayerViewModel>())
                 {
-                    <tr>
+                    var isAsleep = player.Mode == PlayerMode.Asleep;
+                    <tr class="@(isAsleep ? "asleep" : "")">
                         <td>
                             @player.Name
                         </td>

--- a/src/PlanningPoker.Client/Pages/Session/_sessionRenderingComponent.razor
+++ b/src/PlanningPoker.Client/Pages/Session/_sessionRenderingComponent.razor
@@ -19,12 +19,17 @@
                 @foreach (var player in Server?.Players?.Where(p => p.Type == PlayerType.Participant) ?? Enumerable.Empty<PlayerViewModel>())
                 {
                     var hasVoted = Server?.CurrentSession?.Votes?.ContainsKey(player.PublicId.ToString()) ?? false;
+                    var isAsleep = player.Mode == PlayerMode.Asleep;
                     var currentPlayerVote = hasVoted ? Server.CurrentSession.Votes[player.PublicId.ToString()] : string.Empty;
-                    <tr class="@(hasVoted ? "table-success" : "")">
+                    <tr class="@(hasVoted ? "table-success" : "") @(isAsleep ? "asleep" : "")">
                         <td>
                             @if (hasVoted)
                             {
                                 <span class="oi oi-check"></span>
+                            }
+                            @if (isAsleep)
+                            {
+                                <span class="oi oi-moon"></span>
                             }
                         </td>
                         <td>

--- a/src/PlanningPoker.Client/Storage/ServerSession.cs
+++ b/src/PlanningPoker.Client/Storage/ServerSession.cs
@@ -7,6 +7,7 @@ namespace PlanningPoker.Client.Storage
     {
         public Guid ServerId { get; set; }
         public string? Username { get; set; }
+        public Guid RecoveryId { get; set; }
         public PlayerType Type { get; set; }
     }
 }

--- a/src/PlanningPoker.Client/wwwroot/css/site.css
+++ b/src/PlanningPoker.Client/wwwroot/css/site.css
@@ -136,8 +136,11 @@ img.navbar-icon {
     color: #bdb4b4;
 }
 
-/* END SESSION RENDERING */
+.table .asleep {
+    opacity: 0.3;
+}
 
+/* END SESSION RENDERING */
 #blazor-error-ui {
     background: lightyellow;
     bottom: 0;

--- a/src/PlanningPoker.Engine.Core.Models/Player.cs
+++ b/src/PlanningPoker.Engine.Core.Models/Player.cs
@@ -12,6 +12,7 @@
             PublicId = publicId;
             Name = name;
             Type = type;
+            Mode = PlayerMode.Awake;
         }
         
         public string Id { get; set; }
@@ -21,5 +22,7 @@
         public string Name { get; set; }
 
         public PlayerType Type { get; set; }
+
+        public PlayerMode Mode { get; set; }
     }
 }

--- a/src/PlanningPoker.Engine.Core.Models/Player.cs
+++ b/src/PlanningPoker.Engine.Core.Models/Player.cs
@@ -1,14 +1,18 @@
-﻿namespace PlanningPoker.Engine.Core.Models
+﻿using System;
+
+namespace PlanningPoker.Engine.Core.Models
 {
     public class Player
     {
         public Player(
             string id, 
+            Guid recoveryId,
             int publicId, 
             string name, 
             PlayerType type)
         {
             Id = id;
+            RecoveryId = recoveryId;
             PublicId = publicId;
             Name = name;
             Type = type;
@@ -16,6 +20,8 @@
         }
         
         public string Id { get; set; }
+
+        public Guid RecoveryId { get; set; }
         
         public int PublicId { get; set; }
 

--- a/src/PlanningPoker.Engine.Core.Models/PlayerMode.cs
+++ b/src/PlanningPoker.Engine.Core.Models/PlayerMode.cs
@@ -1,0 +1,8 @@
+﻿namespace PlanningPoker.Engine.Core.Models
+{
+    public enum PlayerMode
+    {
+        Awake = 100,
+        Asleep = 200
+    }
+}

--- a/src/PlanningPoker.Engine.Core.Models/Poker/PokerSession.cs
+++ b/src/PlanningPoker.Engine.Core.Models/Poker/PokerSession.cs
@@ -18,9 +18,15 @@ namespace PlanningPoker.Engine.Core.Models.Poker
         public bool CanShow(IDictionary<string, Player> participants)
         {
             return 
-                Votes.Count != 0 
-                && Votes.Count == participants.Count(p => p.Value.Type == PlayerType.Participant) 
-                && !IsShown;
+                Votes.Count != 0
+                && !IsShown
+                && AllAwakeParticipantsVoted(participants);
+        }
+
+        private bool AllAwakeParticipantsVoted(IDictionary<string, Player> participants)
+        {
+            var awakeParticipants = participants.Values.Where(p => p.Type == PlayerType.Participant && p.Mode == PlayerMode.Awake).Select(p => p.PublicId);
+            return awakeParticipants.All(id => Votes.ContainsKey(id));
         }
 
         public bool CanClear => Votes.Any();

--- a/src/PlanningPoker.Engine.Core/PlanningPokerEngine.cs
+++ b/src/PlanningPoker.Engine.Core/PlanningPokerEngine.cs
@@ -14,7 +14,7 @@ namespace PlanningPoker.Engine.Core
         event EventHandler<RoomClearedEventArgs> RoomCleared;
 
         void Kick(Guid id, string initiatingPlayerPrivateId, int playerPublicIdToRemove);
-        void RemovePlayerFromAllRooms(string playerPrivateId);
+        void SleepInAllRooms(string playerPrivateId);
         (bool wasCreated, Guid? serverId, string? validationMessages) CreateRoom(string desiredCardSet);
         Player JoinRoom(Guid id, string playerName, string playerPrivateId, PlayerType type);
         void Vote(Guid serverId, string playerPrivateId, string vote);
@@ -53,9 +53,9 @@ namespace PlanningPoker.Engine.Core
             }
         }
 
-        public void RemovePlayerFromAllRooms(string playerPrivateId)
+        public void SleepInAllRooms(string playerPrivateId)
         {
-            var serversWithPlayer = ServerManager.RemovePlayerFromAllServers(_serverStore.All(), playerPrivateId);
+            var serversWithPlayer = ServerManager.SetPlayerToSleepOnAllServers(_serverStore.All(), playerPrivateId);
             foreach (var server in serversWithPlayer)
             {
                 RaiseRoomUpdated(server.Id, server);
@@ -96,6 +96,7 @@ namespace PlanningPoker.Engine.Core
 
             var player = ServerManager.GetPlayer(server, playerPrivateId);
             if (player.Type == PlayerType.Observer) throw new VoteException($"Player is of type '{player.Type}' and cannot vote.");
+            if (player.Mode == PlayerMode.Asleep) throw new VoteException($"Player is in mode '{player.Mode}', and cannot vote.");
 
             SessionManager.SetVote(server.CurrentSession, player.PublicId, vote);
             RaiseRoomUpdated(server.Id, server);
@@ -110,6 +111,7 @@ namespace PlanningPoker.Engine.Core
 
             var player = ServerManager.GetPlayer(server, playerPrivateId);
             if (player.Type == PlayerType.Observer) throw new VoteException($"Player is of type '{player.Type}' and cannot vote.");
+            if (player.Mode == PlayerMode.Asleep) throw new VoteException($"Player is in mode '{player.Mode}', and cannot vote.");
 
             SessionManager.RemoveVote(server.CurrentSession, player.PublicId);
             RaiseRoomUpdated(server.Id, server);

--- a/src/PlanningPoker.Engine.Core/PlanningPokerEngine.cs
+++ b/src/PlanningPoker.Engine.Core/PlanningPokerEngine.cs
@@ -16,7 +16,7 @@ namespace PlanningPoker.Engine.Core
         void Kick(Guid id, string initiatingPlayerPrivateId, int playerPublicIdToRemove);
         void SleepInAllRooms(string playerPrivateId);
         (bool wasCreated, Guid? serverId, string? validationMessages) CreateRoom(string desiredCardSet);
-        Player JoinRoom(Guid id, string playerName, string playerPrivateId, PlayerType type);
+        Player JoinRoom(Guid id, Guid recoveryId, string playerName, string playerPrivateId, PlayerType type);
         void Vote(Guid serverId, string playerPrivateId, string vote);
         void RedactVote(Guid serverId, string playerPrivateId);
         void ClearVotes(Guid serverId, string playerPrivateId);
@@ -74,14 +74,14 @@ namespace PlanningPoker.Engine.Core
             return (true, server.Id, validationMessage);
         }
 
-        public Player JoinRoom(Guid id, string playerName, string playerPrivateId, PlayerType type)
+        public Player JoinRoom(Guid id, Guid recoveryId, string playerName, string playerPrivateId, PlayerType type)
         {
             if (string.IsNullOrWhiteSpace(playerName)) throw new MissingPlayerNameException();
 
             var server = _serverStore.Get(id);
             
             var formattedPlayerName = playerName.Length > MaxPlayerNameLength ? playerName.Substring(0, MaxPlayerNameLength) : playerName;
-            var newPlayer = ServerManager.AddOrUpdatePlayer(server, playerPrivateId, formattedPlayerName, type);
+            var newPlayer = ServerManager.AddOrUpdatePlayer(server, recoveryId, playerPrivateId, formattedPlayerName, type);
             RaiseRoomUpdated(id, server);
             RaiseLogUpdated(id, newPlayer.Name, "Joined the server.");
             return newPlayer;

--- a/src/PlanningPoker.Hub.Client.Abstractions/IPlanningPokerHubClient.cs
+++ b/src/PlanningPoker.Hub.Client.Abstractions/IPlanningPokerHubClient.cs
@@ -16,7 +16,7 @@ namespace PlanningPoker.Hub.Client.Abstractions
 
         Task<ServerCreationResult> CreateServer(string cardSet);
 
-        Task<PlayerViewModel> JoinServer(Guid serverId, string playerName, PlayerType playerType);
+        Task<PlayerViewModel> JoinServer(Guid serverId, Guid recoveryId, string playerName, PlayerType playerType);
 
         Task KickPlayer(Guid serverId, string initiatingPlayerPrivateId, int kickedPlayerPublicId);
 

--- a/src/PlanningPoker.Hub.Client.Abstractions/IPlanningPokerHubClient.cs
+++ b/src/PlanningPoker.Hub.Client.Abstractions/IPlanningPokerHubClient.cs
@@ -10,6 +10,8 @@ namespace PlanningPoker.Hub.Client.Abstractions
 
         Task Connect(Guid serverId);
 
+        Task Disconnect();
+        
         Task ClearVotes(Guid serverId);
 
         Task<ServerCreationResult> CreateServer(string cardSet);

--- a/src/PlanningPoker.Hub.Client.Abstractions/ViewModels/PlayerMode.cs
+++ b/src/PlanningPoker.Hub.Client.Abstractions/ViewModels/PlayerMode.cs
@@ -1,0 +1,8 @@
+﻿namespace PlanningPoker.Hub.Client.Abstractions.ViewModels
+{
+    public enum PlayerMode
+    {
+        Awake = 100,
+        Asleep = 200
+    }
+}

--- a/src/PlanningPoker.Hub.Client.Abstractions/ViewModels/PlayerViewModel.cs
+++ b/src/PlanningPoker.Hub.Client.Abstractions/ViewModels/PlayerViewModel.cs
@@ -9,5 +9,7 @@
         public string? Name { get; set; }
 
         public PlayerType Type { get; set; }
+
+        public PlayerMode Mode { get; set; }
     }
 }

--- a/src/PlanningPoker.Hub.Client.Abstractions/ViewModels/PlayerViewModel.cs
+++ b/src/PlanningPoker.Hub.Client.Abstractions/ViewModels/PlayerViewModel.cs
@@ -1,8 +1,12 @@
-﻿namespace PlanningPoker.Hub.Client.Abstractions.ViewModels
+﻿using System;
+
+namespace PlanningPoker.Hub.Client.Abstractions.ViewModels
 {
     public class PlayerViewModel
     {
         public string? Id { get; set; }
+
+        public Guid? RecoveryId { get; set; }
 
         public int PublicId { get; set; }
 

--- a/src/PlanningPoker.Hub.Client/PlanningPokerHubClient.cs
+++ b/src/PlanningPoker.Hub.Client/PlanningPokerHubClient.cs
@@ -39,9 +39,9 @@ namespace PlanningPoker.Hub.Client
             return _hubConnection.InvokeAsync<ServerCreationResult>(HubEndpointRoutes.Create, cardSet);
         }
 
-        public Task<PlayerViewModel> JoinServer(Guid serverId, string playerName, PlayerType playerType)
+        public Task<PlayerViewModel> JoinServer(Guid serverId, Guid recoveryId, string playerName, PlayerType playerType)
         {
-            return _hubConnection.InvokeAsync<PlayerViewModel>(HubEndpointRoutes.Join, serverId, playerName, playerType);
+            return _hubConnection.InvokeAsync<PlayerViewModel>(HubEndpointRoutes.Join, serverId, recoveryId, playerName, playerType);
         }
 
         public Task KickPlayer(Guid serverId, string initiatingPlayerPublicId, int kickedPlayerPublicId)

--- a/src/PlanningPoker.Hub.Client/PlanningPokerHubClient.cs
+++ b/src/PlanningPoker.Hub.Client/PlanningPokerHubClient.cs
@@ -24,6 +24,11 @@ namespace PlanningPoker.Hub.Client
             await Connected.Invoke();
         }
 
+        public async Task Disconnect()
+        {
+            await _hubConnection.StopAsync();
+        }
+        
         public Task ClearVotes(Guid serverId)
         {
             return _hubConnection.InvokeAsync(HubEndpointRoutes.Clear, serverId);

--- a/src/PlanningPoker.Server.Infrastructure/HostedServices/CleanupServerJob.cs
+++ b/src/PlanningPoker.Server.Infrastructure/HostedServices/CleanupServerJob.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
 using PlanningPoker.Engine.Core;
+using PlanningPoker.Engine.Core.Models;
 
 namespace PlanningPoker.Server.Infrastructure.HostedServices
 {
@@ -31,8 +32,8 @@ namespace PlanningPoker.Server.Infrastructure.HostedServices
                 if (cancellationToken.IsCancellationRequested) break;
 
                 var isOld = createdThreshold > server.Created;
-                var isEmpty = !server.Players.Any();
-                if (isOld && isEmpty)
+                var isEmptyOrAsleep = server.Players.All(p => p.Value.Mode != PlayerMode.Awake);
+                if (isOld && isEmptyOrAsleep)
                 {
                     _serverStore.Remove(server);
                 }

--- a/src/PlanningPoker.Server/Hubs/PlanningPokerHub.cs
+++ b/src/PlanningPoker.Server/Hubs/PlanningPokerHub.cs
@@ -31,7 +31,7 @@ namespace PlanningPoker.Server.Hubs
         
         public override async Task OnDisconnectedAsync(Exception exception)
         {
-            _pokerEngine.RemovePlayerFromAllRooms(GetPlayerPrivateId());
+            _pokerEngine.SleepInAllRooms(GetPlayerPrivateId());
             await base.OnDisconnectedAsync(exception);
         }
 

--- a/src/PlanningPoker.Server/Hubs/PlanningPokerHub.cs
+++ b/src/PlanningPoker.Server/Hubs/PlanningPokerHub.cs
@@ -48,9 +48,9 @@ namespace PlanningPoker.Server.Hubs
             return creationResult;
         }
 
-        public PlayerViewModel Join(Guid id, string playerName, Engine.Core.Models.PlayerType type)
+        public PlayerViewModel Join(Guid id, Guid recoveryId, string playerName, Engine.Core.Models.PlayerType type)
         {
-            var joinedPlayer = _pokerEngine.JoinRoom(id, playerName, GetPlayerPrivateId(), type);
+            var joinedPlayer = _pokerEngine.JoinRoom(id, recoveryId, playerName, GetPlayerPrivateId(), type);
             return joinedPlayer.Map(includePrivateId: true);
         }
 

--- a/src/PlanningPoker.Server/ViewModelMappers/PlayerModeViewModelMapper .cs
+++ b/src/PlanningPoker.Server/ViewModelMappers/PlayerModeViewModelMapper .cs
@@ -1,0 +1,18 @@
+﻿using System;
+using PlanningPoker.Hub.Client.Abstractions.ViewModels;
+
+namespace PlanningPoker.Server.ViewModelMappers
+{
+    public static class PlayerModeViewModelMapper
+    {
+        public static PlayerMode Map(this Engine.Core.Models.PlayerMode playerMode)
+        {
+            return playerMode switch
+            {
+                Engine.Core.Models.PlayerMode.Awake => PlayerMode.Awake,
+                Engine.Core.Models.PlayerMode.Asleep => PlayerMode.Asleep,
+                _ => throw new ArgumentOutOfRangeException(nameof(playerMode), playerMode, null)
+            };
+        }
+    }
+}

--- a/src/PlanningPoker.Server/ViewModelMappers/PlayerTypeViewModelMapper.cs
+++ b/src/PlanningPoker.Server/ViewModelMappers/PlayerTypeViewModelMapper.cs
@@ -1,16 +1,16 @@
 ﻿using System;
-using PlayerType = PlanningPoker.Engine.Core.Models.PlayerType;
+using PlanningPoker.Hub.Client.Abstractions.ViewModels;
 
 namespace PlanningPoker.Server.ViewModelMappers
 {
     public static class PlayerTypeViewModelMapper
     {
-        public static Hub.Client.Abstractions.ViewModels.PlayerType Map(this PlayerType playerType)
+        public static PlayerType Map(this Engine.Core.Models.PlayerType playerType)
         {
             return playerType switch
             {
-                PlayerType.Participant => Hub.Client.Abstractions.ViewModels.PlayerType.Participant,
-                PlayerType.Observer => Hub.Client.Abstractions.ViewModels.PlayerType.Observer,
+                Engine.Core.Models.PlayerType.Participant => PlayerType.Participant,
+                Engine.Core.Models.PlayerType.Observer => PlayerType.Observer,
                 _ => throw new ArgumentOutOfRangeException(nameof(playerType), playerType, null)
             };
         }

--- a/src/PlanningPoker.Server/ViewModelMappers/PlayerViewModelMapper.cs
+++ b/src/PlanningPoker.Server/ViewModelMappers/PlayerViewModelMapper.cs
@@ -12,7 +12,8 @@ namespace PlanningPoker.Server.ViewModelMappers
                 Id = includePrivateId ? player.Id : null,
                 PublicId = player.PublicId,
                 Name = player.Name,
-                Type = player.Type.Map()
+                Type = player.Type.Map(),
+                Mode = player.Mode.Map()
             };
 
             return viewModel;

--- a/src/PlanningPoker.Server/ViewModelMappers/PlayerViewModelMapper.cs
+++ b/src/PlanningPoker.Server/ViewModelMappers/PlayerViewModelMapper.cs
@@ -1,4 +1,5 @@
-﻿using PlanningPoker.Engine.Core.Models;
+﻿using System;
+using PlanningPoker.Engine.Core.Models;
 using PlanningPoker.Hub.Client.Abstractions.ViewModels;
 
 namespace PlanningPoker.Server.ViewModelMappers
@@ -10,6 +11,7 @@ namespace PlanningPoker.Server.ViewModelMappers
             var viewModel = new PlayerViewModel
             {
                 Id = includePrivateId ? player.Id : null,
+                RecoveryId = includePrivateId ? (Guid?)player.RecoveryId : null,
                 PublicId = player.PublicId,
                 Name = player.Name,
                 Type = player.Type.Map(),

--- a/tests/PlanningPoker.FunctionalTests/Tests/Hubs/PlanningPokerHubTestBuilder.cs
+++ b/tests/PlanningPoker.FunctionalTests/Tests/Hubs/PlanningPokerHubTestBuilder.cs
@@ -53,12 +53,12 @@ namespace PlanningPoker.FunctionalTests.Tests.Hubs
 
         public PlanningPokerHubTestBuilder WithPlayer(Guid serverId, out PlayerViewModel player)
         {
-            return WithPlayer(serverId, PlayerType.Participant, Guid.NewGuid().ToString(), out player);
+            return WithPlayer(serverId, Guid.NewGuid(), PlayerType.Participant, Guid.NewGuid().ToString(), out player);
         }
 
         public PlanningPokerHubTestBuilder WithObserver(Guid serverId, out PlayerViewModel player)
         {
-            return WithPlayer(serverId, PlayerType.Observer, Guid.NewGuid().ToString(), out player);
+            return WithPlayer(serverId, Guid.NewGuid(), PlayerType.Observer, Guid.NewGuid().ToString(), out player);
         }
 
         public PlanningPokerHubTestBuilder WithPlayerVoted(Guid serverId, string playerPrivateId, string vote)
@@ -106,11 +106,11 @@ namespace PlanningPoker.FunctionalTests.Tests.Hubs
             return this;
         }
 
-        private PlanningPokerHubTestBuilder WithPlayer(Guid serverId, PlayerType playerType, string playerName, out PlayerViewModel player)
+        private PlanningPokerHubTestBuilder WithPlayer(Guid serverId, Guid recoveryId, PlayerType playerType, string playerName, out PlayerViewModel player)
         {
             HubClient.Connect(serverId).GetAwaiter().GetResult();
             player = AwaitEventResult<PokerServerViewModel, PlayerViewModel>(
-                () => HubClient.JoinServer(serverId, playerName, playerType),
+                () => HubClient.JoinServer(serverId, recoveryId, playerName, playerType),
                 HubClient.OnSessionUpdated).GetAwaiter().GetResult();
             return this;
         }

--- a/tests/PlanningPoker.FunctionalTests/Tests/Hubs/PlanningPokerHubTestBuilder.cs
+++ b/tests/PlanningPoker.FunctionalTests/Tests/Hubs/PlanningPokerHubTestBuilder.cs
@@ -12,12 +12,13 @@ namespace PlanningPoker.FunctionalTests.Tests.Hubs
     public class PlanningPokerHubTestBuilder
     {
         private const string HubBaseAddress = "/hubs/poker";
+        private HubConnection _hubConnection;
 
         public PlanningPokerHubTestBuilder(PlanningPokerWebApplicationFactory factory)
         {
-            var hubConnection = CreateConnection(factory);
-            hubConnection.StartAsync().GetAwaiter().GetResult();
-            HubClient = new PlanningPokerHubClient(hubConnection);
+            _hubConnection = CreateConnection(factory);
+            _hubConnection.StartAsync().GetAwaiter().GetResult();
+            HubClient = new PlanningPokerHubClient(_hubConnection);
             HubClient.OnConnected(() => Task.CompletedTask);
         }
 

--- a/tests/PlanningPoker.FunctionalTests/Tests/Hubs/PlanningPokerHubTests_Join.cs
+++ b/tests/PlanningPoker.FunctionalTests/Tests/Hubs/PlanningPokerHubTests_Join.cs
@@ -16,9 +16,10 @@ namespace PlanningPoker.FunctionalTests.Tests.Hubs
             var builder = CreateBuilder();
             var expectedPlayerName = "playerName1";
             var expectedPlayerType = PlayerType.Participant;
+            var recoveryId = Guid.NewGuid();
 
             // Act
-            var exceptionRecord = await Record.ExceptionAsync(() => builder.HubClient.JoinServer(Guid.NewGuid(), expectedPlayerName, expectedPlayerType));
+            var exceptionRecord = await Record.ExceptionAsync(() => builder.HubClient.JoinServer(Guid.NewGuid(), recoveryId, expectedPlayerName, expectedPlayerType));
 
             // Assert
             Assert.NotNull(exceptionRecord);
@@ -32,9 +33,10 @@ namespace PlanningPoker.FunctionalTests.Tests.Hubs
             builder.WithServer(out var serverId);
             var expectedPlayerName = "playerName1";
             var expectedPlayerType = PlayerType.Participant;
+            var recoveryId = Guid.NewGuid();
 
             // Act
-            var result = await builder.HubClient.JoinServer(serverId, expectedPlayerName, expectedPlayerType);
+            var result = await builder.HubClient.JoinServer(serverId, recoveryId, expectedPlayerName, expectedPlayerType);
 
             // Assert
             Assert.NotNull(result);
@@ -69,7 +71,7 @@ namespace PlanningPoker.FunctionalTests.Tests.Hubs
             var results = new List<PlayerViewModel?>();
             for (var i = 0; i < playerConnections.Count; i++)
             {
-                results.Add(await playerConnections[i].JoinServer(serverId, expectedPlayerNames[i], expectedPlayerType));
+                results.Add(await playerConnections[i].JoinServer(serverId, Guid.NewGuid(), expectedPlayerNames[i], expectedPlayerType));
             }
 
             // Assert
@@ -91,9 +93,10 @@ namespace PlanningPoker.FunctionalTests.Tests.Hubs
             builder.WithServer(out var serverId);
             var expectedPlayerName = "";
             var expectedPlayerType = PlayerType.Participant;
+            var recoveryId = Guid.NewGuid();
 
             // Act
-            var exceptionRecord = await Record.ExceptionAsync(() => builder.HubClient.JoinServer(serverId, expectedPlayerName, expectedPlayerType));
+            var exceptionRecord = await Record.ExceptionAsync(() => builder.HubClient.JoinServer(serverId, recoveryId, expectedPlayerName, expectedPlayerType));
 
             // Assert
             Assert.NotNull(exceptionRecord);
@@ -107,9 +110,10 @@ namespace PlanningPoker.FunctionalTests.Tests.Hubs
             builder.WithServer(out var serverId);
             var expectedPlayerName = "observerName1";
             var expectedPlayerType = PlayerType.Observer;
+            var recoveryId = Guid.NewGuid();
 
             // Act
-            var result = await builder.HubClient.JoinServer(serverId, expectedPlayerName, expectedPlayerType);
+            var result = await builder.HubClient.JoinServer(serverId, recoveryId, expectedPlayerName, expectedPlayerType);
 
             // Assert
             Assert.NotNull(result);

--- a/tests/PlanningPoker.FunctionalTests/Tests/Hubs/PlanningPokerHubTests_SleepPlayer.cs
+++ b/tests/PlanningPoker.FunctionalTests/Tests/Hubs/PlanningPokerHubTests_SleepPlayer.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using PlanningPoker.Hub.Client.Abstractions.ViewModels;
+using Xunit;
+
+namespace PlanningPoker.FunctionalTests.Tests.Hubs
+{
+    public partial class PlanningPokerHubTests
+    {
+        [Fact]
+        public async Task Sleep_WhenServerDoesNotExist_Ok()
+        {
+            // Arrange
+            var builder = CreateBuilder();
+
+            // Act
+            var exceptionRecord = await Record.ExceptionAsync(() => builder.HubClient.Disconnect());
+
+            // Assert
+            Assert.Null(exceptionRecord);
+        }
+
+        [Fact]
+        public async Task Sleep_WhenServerExistAndPlayerDoesNotExist_Ok()
+        {
+            // Arrange
+            var builder = CreateBuilder();
+            builder.WithServer(out _);
+
+            // Act
+            var exceptionRecord = await Record.ExceptionAsync(() => builder.HubClient.Disconnect());
+
+            // Assert
+            Assert.Null(exceptionRecord);
+        }
+
+        [Fact]
+        public async Task Sleep_WhenPlayerHasVoted_PlayerKeepsVote()
+        {
+            // Arrange
+            var expectedVote = "1";
+            var disconnectingBuilder = CreateBuilder();
+            disconnectingBuilder.WithServer(out var serverId);
+            disconnectingBuilder.WithPlayer(serverId, out var disconnectingPlayer);
+            disconnectingBuilder.WithPlayerVoted(serverId, disconnectingPlayer.Id, expectedVote);
+            var observingBuilder = CreateBuilder()
+                .WithPlayer(serverId, out _);
+            SemaphoreSlim awaitResponse = new SemaphoreSlim(0);
+            bool hasVoted = false;
+            observingBuilder.HubClient.OnSessionUpdated(viewModel =>
+            {
+                hasVoted = viewModel.CurrentSession.Votes.ContainsKey(disconnectingPlayer.PublicId.ToString());
+                awaitResponse.Release();
+            });
+
+            // Act
+            await disconnectingBuilder.HubClient.Disconnect();
+
+            // Assert
+            await awaitResponse.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.True(hasVoted);
+        }
+
+        [Fact]
+        public async Task Sleep_WhenPlayerHasVoted_VotesCanBeShown()
+        {
+            // Arrange
+            var expectedVote = "1";
+            var disconnectingBuilder = CreateBuilder();
+            disconnectingBuilder.WithServer(out var serverId);
+            disconnectingBuilder.WithPlayer(serverId, out _);
+            var observingBuilder = CreateBuilder()
+                .WithPlayer(serverId, out var observingPlayer)
+                .WithPlayerVoted(serverId, observingPlayer.Id, expectedVote);
+            SemaphoreSlim awaitResponse = new SemaphoreSlim(0);
+            bool canShow = false;
+            observingBuilder.HubClient.OnSessionUpdated(viewModel =>
+            {
+                canShow = viewModel.CurrentSession.CanShow;
+                awaitResponse.Release();
+            });
+
+            // Act
+            await disconnectingBuilder.HubClient.Disconnect();
+
+            // Assert
+            await awaitResponse.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.True(canShow);
+        }
+
+        [Fact]
+        public async Task Sleep_WhenNoOneHasVoted_CannotClear()
+        {
+            // Arrange
+            var expectedVote = "1";
+            var disconnectingBuilder = CreateBuilder();
+            disconnectingBuilder.WithServer(out var serverId);
+            disconnectingBuilder.WithPlayer(serverId, out _);
+            var observingBuilder = CreateBuilder()
+                .WithPlayer(serverId, out _);
+            SemaphoreSlim awaitResponse = new SemaphoreSlim(0);
+            bool canClear = false;
+            observingBuilder.HubClient.OnSessionUpdated(viewModel =>
+            {
+                canClear = viewModel.CurrentSession.CanClear;
+                awaitResponse.Release();
+            });
+
+            // Act
+            await disconnectingBuilder.HubClient.Disconnect();
+
+            // Assert
+            await awaitResponse.WaitAsync(TimeSpan.FromSeconds(5));
+            Assert.False(canClear);
+        }
+    }
+}


### PR DESCRIPTION
Modified disconnecting behavior, such that the player is no longer removed from all servers. Instead, the player is marked as 'Asleep', which puts them in a mode which does not affect voting. The sleeping players vote can still be shown, but it is not necessary that the player votes to show all votes.
When the player rejoins or reconnects, the player is awaken again, and behaves like a normal player.