### PR TITLE
Feature/add application insights

### DIFF
--- a/src/PlanningPoker.Server.Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/src/PlanningPoker.Server.Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ namespace PlanningPoker.Server.Infrastructure.Extensions
             services.AddSingleton<IPlanningPokerEngine, PlanningPokerEngine>();
             services.AddSingleton<IDateTimeProvider, DateTimeProvider>();
             services.AddHostedService<CleanupServerJob>();
+            services.AddHostedService<ReportTelemetryJob>();
 
             return services;
         }

--- a/src/PlanningPoker.Server.Infrastructure/HostedServices/CleanupServerJob.cs
+++ b/src/PlanningPoker.Server.Infrastructure/HostedServices/CleanupServerJob.cs
@@ -11,6 +11,7 @@ namespace PlanningPoker.Server.Infrastructure.HostedServices
     public class CleanupServerJob : IHostedService, IDisposable
     {
         private Timer? _timer;
+        private static readonly TimeSpan RunFrequency = TimeSpan.FromMinutes(20);
         private readonly IServerStore _serverStore;
 
         public CleanupServerJob(IServerStore serverStore)
@@ -20,7 +21,7 @@ namespace PlanningPoker.Server.Infrastructure.HostedServices
 
         public Task StartAsync(CancellationToken cancellationToken)
         {
-            _timer = new Timer(_ => RunJob(cancellationToken), null, TimeSpan.Zero, TimeSpan.FromMinutes(20));
+            _timer = new Timer(_ => RunJob(cancellationToken), null, TimeSpan.Zero, RunFrequency);
             return Task.CompletedTask;
         }
 

--- a/src/PlanningPoker.Server.Infrastructure/HostedServices/ReportTelemetryJob.cs
+++ b/src/PlanningPoker.Server.Infrastructure/HostedServices/ReportTelemetryJob.cs
@@ -1,0 +1,72 @@
+﻿using Microsoft.Extensions.Hosting;
+using PlanningPoker.Engine.Core;
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.ApplicationInsights;
+
+namespace PlanningPoker.Server.Infrastructure.HostedServices
+{
+    public class ReportTelemetryJob : IHostedService, IDisposable
+    {
+        private Timer? _timer;
+        private static readonly TimeSpan RunFrequency = TimeSpan.FromMinutes(10);
+        private readonly IServerStore _serverStore;
+        private readonly TelemetryClient _telemetryClient;
+        private const string ReportPlayersMetricName  = "players";
+        private const string ReportSessionsMetricName = "sessions";
+
+        public ReportTelemetryJob(IServerStore serverStore, TelemetryClient telemetryClient)
+        {
+            _serverStore = serverStore;
+            _telemetryClient = telemetryClient;
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            _timer = new Timer(_ => RunJob(), null, TimeSpan.Zero, RunFrequency);
+            return Task.CompletedTask;
+        }
+
+        private void RunJob()
+        {
+            ReportSessions();
+            ReportPlayers();
+        }
+
+        private void ReportSessions()
+        {
+            var allPlayers = _serverStore.All().Count;
+            _telemetryClient.TrackMetric(ReportSessionsMetricName, allPlayers);
+        }
+
+        private void ReportPlayers()
+        {
+            var allPlayers = _serverStore.All().Sum(server => server.Players.Count);
+            _telemetryClient.TrackMetric(ReportPlayersMetricName, allPlayers);
+        }
+
+        
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            _timer?.Change(Timeout.Infinite, Timeout.Infinite);
+            return Task.CompletedTask;
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _timer?.Dispose();
+            }
+        }
+    }
+}

--- a/src/PlanningPoker.Server.Infrastructure/PlanningPoker.Server.Infrastructure.csproj
+++ b/src/PlanningPoker.Server.Infrastructure/PlanningPoker.Server.Infrastructure.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PlanningPoker.Server/PlanningPoker.Server.csproj
+++ b/src/PlanningPoker.Server/PlanningPoker.Server.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="6.0.8" />
   </ItemGroup>
 

--- a/src/PlanningPoker.Server/PlanningPoker.Server.csproj
+++ b/src/PlanningPoker.Server/PlanningPoker.Server.csproj
@@ -7,7 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="6.0.8" />
   </ItemGroup>
 

--- a/src/PlanningPoker.Server/Program.cs
+++ b/src/PlanningPoker.Server/Program.cs
@@ -15,6 +15,7 @@ namespace PlanningPoker.Server
         {
             return WebHost.CreateDefaultBuilder(args)
                 .UseConfiguration(new ConfigurationBuilder()
+                    .AddJsonFile("appsettings.json")
                     .AddCommandLine(args)
                     .Build())
                 .UseStartup<Startup>()

--- a/src/PlanningPoker.Server/Startup.cs
+++ b/src/PlanningPoker.Server/Startup.cs
@@ -13,6 +13,8 @@ namespace PlanningPoker.Server
     {
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddApplicationInsightsTelemetry();
+
             services.RegisterDependencies();
             services.AddSingleton<IPlanningPokerEventBroadcaster, PlanningPokerEventBroadcaster>();
             services.AddSignalR(options =>

--- a/src/PlanningPoker.Server/appsettings.json
+++ b/src/PlanningPoker.Server/appsettings.json
@@ -1,0 +1,7 @@
+﻿{
+    "Logging": {
+        "LogLevel": {
+            "Default": "Warning"
+        }
+    }
+}


### PR DESCRIPTION
* Added ApplicationInsights to gather server-side diagnostics.
* Added periodic telemetry metric collector, to report total number of active sessions and players.

It has always been one of the core philosophies of this project, to not gather any user metrics which potentially can be shared with third-party vendors. I initially extended this to any server-side metrics as well, to ensure there were no grey areas or flexible principles.
By not logging any server-side information, I don't have any insight in unhandled exceptions, downtime or unreported errors, which significantly limits my ability to catch and fix any bugs which may arise.

With your permission, I would like to start logging server-side technical diagnostics (not any user data), to ensure the product can remain as bug-free as possible.

If you find any parts of this that you disagree with, or where I may have misunderstood the extend of data being collected, please join the discussion, and I/we can adjust the code accordingly, to adhere to the core principle, of not logging any user data.

Discussion: https://github.com/PolygeneLubricants/planning-poker/discussions/8