### PR TITLE
Fix/vote average float values

### DIFF
--- a/src/PlanningPoker.Client/Pages/Session/_sessionControlComponent.razor
+++ b/src/PlanningPoker.Client/Pages/Session/_sessionControlComponent.razor
@@ -97,7 +97,7 @@
         return HubClient.ShowVotes(Id);
     }
 
-    IEnumerable<int?> GetVoteMode()
+    IEnumerable<decimal?> GetVoteMode()
     {
         var sortedVoteGroups = Session?.Votes?
             .Select(unparsedVote => DecimalParseOrNull(unparsedVote.Value))

--- a/src/PlanningPoker.Client/Pages/Session/_sessionControlComponent.razor
+++ b/src/PlanningPoker.Client/Pages/Session/_sessionControlComponent.razor
@@ -136,7 +136,7 @@
         }
 
         var totalValidVotes = Session.Votes
-            .Select(unparsedVote => IntParseOrNull(unparsedVote.Value))
+            .Select(unparsedVote => DecimalParseOrNull(unparsedVote.Value))
             .Count(vote => vote != null);
         if (totalValidVotes == 0)
         {

--- a/src/PlanningPoker.Client/Pages/Session/_sessionControlComponent.razor
+++ b/src/PlanningPoker.Client/Pages/Session/_sessionControlComponent.razor
@@ -100,7 +100,7 @@
     IEnumerable<int?> GetVoteMode()
     {
         var sortedVoteGroups = Session?.Votes?
-            .Select(unparsedVote => IntParseOrNull(unparsedVote.Value))
+            .Select(unparsedVote => DecimalParseOrNull(unparsedVote.Value))
             .Where(vote => vote != null)
             .GroupBy(parsedVote => parsedVote)
             .Where(group => group.Key.HasValue)

--- a/src/PlanningPoker.Client/Pages/Session/_sessionControlComponent.razor
+++ b/src/PlanningPoker.Client/Pages/Session/_sessionControlComponent.razor
@@ -157,12 +157,6 @@
         return parsed ? (decimal?)parsedResult : null;
     }
 
-    int? IntParseOrNull(string val)
-    {
-        var parsed = int.TryParse(val, out var parsedResult);
-        return parsed ? (int?)parsedResult : null;
-    }
-
     [Parameter]
     public Guid Id { get; set; }
 


### PR DESCRIPTION
### Issue
- When using floating point values as cards, average & mode calculations are off
- This is because those calculations only take the integer votes into account

Example in screenshot, where I would expect the:
- Average to be 1.5
- Mode to be 1.5 as well

Instead we have:
- Average of 3.8 (~7.5 / 2)
- Mode of (1, 2)
<img width="885" alt="Screenshot 2022-09-13 at 22 42 49" src="https://user-images.githubusercontent.com/22749794/190005919-21cc2279-1201-49f2-9573-7529287959b4.png">


### Resolution
I've replaced the use of IntParseOrNull by DecimalParseOrNull & removed the no longer used IntParseOrNull.
Please note I'm not used to C# and didn't know how to run these changes locally to validate them.