### PR TITLE
Feature/12/fix 404

### DIFF
--- a/src/PlanningPoker.Client/App.razor
+++ b/src/PlanningPoker.Client/App.razor
@@ -4,7 +4,19 @@
     </Found>
     <NotFound>
         <LayoutView Layout="@typeof(MainLayout)">
-            <p>Sorry, there's nothing at this address.</p>
+            <div class="card">
+                <div class="card-body">
+                    <div class="row">
+                        <div class="col">
+                            <h2>404 - Nothing at this URL</h2>
+                            <p>
+                                The URL you have entered is not routed in JustPlanningPoker. 
+                                If you believe this is a mistake, feel free to raise an issue in the Github project, linked in the footer of this page.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </LayoutView>
     </NotFound>
 </Router>

--- a/src/PlanningPoker.Client/Pages/Session/ServerDoesNotExist.razor
+++ b/src/PlanningPoker.Client/Pages/Session/ServerDoesNotExist.razor
@@ -1,0 +1,26 @@
+﻿<div class="card">
+    <div class="card-body">
+        <div class="row">
+            <div class="col">
+                <h2>404 - Room does not exist</h2>
+                <p>
+                    The planning room you are trying to enter, with id, <i>@Id</i>, does not exist.
+                </p>
+                <p>
+                    Rooms are temporary, and will be cleaned up when the room has been empty for an hour.
+                    Please check the server id, and ensure you did not copy-paste an old room, from a previous planning session.
+                    If you did, feel free to create a new session from the front page.
+                </p>
+            </div>
+        </div>
+    </div>
+</div>
+
+@code
+{
+    [Parameter]
+    public string Id { get; set; }
+
+    [Parameter]
+    public EventCallback<string> IdChanged { get; set; }
+}

--- a/src/PlanningPoker.Client/Pages/Session/Session.razor
+++ b/src/PlanningPoker.Client/Pages/Session/Session.razor
@@ -14,7 +14,7 @@
     <_sessionLogComponent @bind-HubClient="_hubClient" />
 }
 
-@if (_currentPlayer == null)
+@if (_currentPlayer == null && _serverExists)
 {
     <div class="card">
         <div class="card-body">
@@ -56,6 +56,11 @@
     </div>
 }
 
+@if (!_serverExists)
+{
+    <ServerDoesNotExist @bind-Id="_id" />
+}
+
 <_notificationsComponent  @bind-HubClient="_hubClient" />
 
 @code {
@@ -80,11 +85,19 @@
         set
         {
             _id = value;
-            _parsedId = Guid.Parse(_id);
+            var validId = Guid.TryParse(_id, out var result);
+            if (!validId)
+            {
+                _serverExists = false;
+            }
+
+            _parsedId = result;
         }
     }
 
     private Guid _parsedId;
+
+    private bool _serverExists = true;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -101,6 +114,7 @@
             .Build();
 
         _hubClient = new PlanningPokerHubClient(connection);
+
         _hubClient.OnSessionUpdated(newServer =>
         {
             CurrentServer = newServer;
@@ -134,6 +148,12 @@
         });
 
         await connection.StartAsync();
+        await VerifyServerExists();
+    }
+
+    async Task VerifyServerExists()
+    {
+        _serverExists = await _hubClient.Exists(_parsedId);
     }
 
     async Task ReconnectIfApplicable()

--- a/src/PlanningPoker.Engine.Core/IServerStore.cs
+++ b/src/PlanningPoker.Engine.Core/IServerStore.cs
@@ -8,6 +8,8 @@ namespace PlanningPoker.Engine.Core
     {
         PokerServer Create(IList<string> cardSet);
 
+        bool Exists(Guid id);
+
         PokerServer Get(Guid id);
         
         ICollection<PokerServer> All();

--- a/src/PlanningPoker.Engine.Core/PlanningPokerEngine.cs
+++ b/src/PlanningPoker.Engine.Core/PlanningPokerEngine.cs
@@ -16,6 +16,7 @@ namespace PlanningPoker.Engine.Core
         void Kick(Guid id, string initiatingPlayerPrivateId, int playerPublicIdToRemove);
         void SleepInAllRooms(string playerPrivateId);
         (bool wasCreated, Guid? serverId, string? validationMessages) CreateRoom(string desiredCardSet);
+        bool RoomExists(Guid roomId);
         Player JoinRoom(Guid id, Guid recoveryId, string playerName, string playerPrivateId, PlayerType type);
         void Vote(Guid serverId, string playerPrivateId, string vote);
         void RedactVote(Guid serverId, string playerPrivateId);
@@ -72,6 +73,11 @@ namespace PlanningPoker.Engine.Core
 
             var server = _serverStore.Create(cardSet);
             return (true, server.Id, validationMessage);
+        }
+
+        public bool RoomExists(Guid roomId)
+        {
+            return _serverStore.Exists(roomId);
         }
 
         public Player JoinRoom(Guid id, Guid recoveryId, string playerName, string playerPrivateId, PlayerType type)

--- a/src/PlanningPoker.Hub.Client.Abstractions/IPlanningPokerHubClient.cs
+++ b/src/PlanningPoker.Hub.Client.Abstractions/IPlanningPokerHubClient.cs
@@ -16,6 +16,8 @@ namespace PlanningPoker.Hub.Client.Abstractions
 
         Task<ServerCreationResult> CreateServer(string cardSet);
 
+        Task<bool> Exists(Guid serverId);
+
         Task<PlayerViewModel> JoinServer(Guid serverId, Guid recoveryId, string playerName, PlayerType playerType);
 
         Task KickPlayer(Guid serverId, string initiatingPlayerPrivateId, int kickedPlayerPublicId);

--- a/src/PlanningPoker.Hub.Client/HubEndpointRoutes.cs
+++ b/src/PlanningPoker.Hub.Client/HubEndpointRoutes.cs
@@ -5,6 +5,7 @@
         public const string Clear = "Clear";
         public const string Connect = "Connect";
         public const string Create = "Create";
+        public const string Exists = "Exists";
         public const string Join = "Join";
         public const string Kick = "Kick";
         public const string Show = "Show";

--- a/src/PlanningPoker.Hub.Client/PlanningPokerHubClient.cs
+++ b/src/PlanningPoker.Hub.Client/PlanningPokerHubClient.cs
@@ -39,6 +39,11 @@ namespace PlanningPoker.Hub.Client
             return _hubConnection.InvokeAsync<ServerCreationResult>(HubEndpointRoutes.Create, cardSet);
         }
 
+        public Task<bool> Exists(Guid serverId)
+        {
+            return _hubConnection.InvokeAsync<bool>(HubEndpointRoutes.Exists, serverId);
+        }
+
         public Task<PlayerViewModel> JoinServer(Guid serverId, Guid recoveryId, string playerName, PlayerType playerType)
         {
             return _hubConnection.InvokeAsync<PlayerViewModel>(HubEndpointRoutes.Join, serverId, recoveryId, playerName, playerType);

--- a/src/PlanningPoker.Server.Infrastructure/ServerStore.cs
+++ b/src/PlanningPoker.Server.Infrastructure/ServerStore.cs
@@ -23,6 +23,11 @@ namespace PlanningPoker.Server.Infrastructure
             return newServer;
         }
 
+        public bool Exists(Guid id)
+        {
+            return _servers.ContainsKey(id);
+        }
+
         public PokerServer Get(Guid id)
         {
             return _servers[id];

--- a/src/PlanningPoker.Server/Hubs/PlanningPokerHub.cs
+++ b/src/PlanningPoker.Server/Hubs/PlanningPokerHub.cs
@@ -48,6 +48,11 @@ namespace PlanningPoker.Server.Hubs
             return creationResult;
         }
 
+        public bool Exists(Guid roomId)
+        {
+            return _pokerEngine.RoomExists(roomId);
+        }
+
         public PlayerViewModel Join(Guid id, Guid recoveryId, string playerName, Engine.Core.Models.PlayerType type)
         {
             var joinedPlayer = _pokerEngine.JoinRoom(id, recoveryId, playerName, GetPlayerPrivateId(), type);

--- a/tests/PlanningPoker.FunctionalTests/Tests/Hubs/PlanningPokerHubTests_Exists.cs
+++ b/tests/PlanningPoker.FunctionalTests/Tests/Hubs/PlanningPokerHubTests_Exists.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace PlanningPoker.FunctionalTests.Tests.Hubs
+{
+    public partial class PlanningPokerHubTests
+    {
+        [Fact]
+        public async Task Exists_WhenServerExists_ReturnsTrue()
+        {
+            // Arrange
+            var builder = CreateBuilder();
+            builder.WithServer(out var createdServerId);
+
+            // Act
+            var exists = await builder.HubClient.Exists(createdServerId);
+
+            // Assert
+            Assert.True(exists);
+        }
+
+        [Fact]
+        public async Task Exists_WhenServerDoesNotExists_ReturnsFalse()
+        {
+            // Arrange
+            var wrongServerId = new Guid("859D0069-6F21-4A7D-8D87-987861240142");
+
+            var builder = CreateBuilder();
+            builder.WithServer(out _);
+
+            // Act
+            var exists = await builder.HubClient.Exists(wrongServerId);
+
+            // Assert
+            Assert.False(exists);
+        }
+
+        [Fact]
+        public async Task Exists_WhenServerNoServersExist_ReturnsFalse()
+        {
+            // Arrange
+            var wrongServerId = new Guid("859D0069-6F21-4A7D-8D87-987861240142");
+
+            var builder = CreateBuilder();
+
+            // Act
+            var exists = await builder.HubClient.Exists(wrongServerId);
+
+            // Assert
+            Assert.False(exists);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #12 by doing a preliminary exists-check on the server, to ensure it is joinable. If the server does not exist, the user will be presented with a 404 page.

This is resolution B from the issue. I found this was a better fix, as the user will know whether the server exists before attempting to join, which could otherwise cause frustration, as the user would have inputted a user name before being presented with this information.