### PR TITLE
bugfix/17/replace-moq

### DIFF
--- a/tests/PlanningPoker.FunctionalTests/PlanningPoker.FunctionalTests.csproj
+++ b/tests/PlanningPoker.FunctionalTests/PlanningPoker.FunctionalTests.csproj
@@ -10,7 +10,6 @@
     <PackageReference Include="AutoFixture" Version="4.17.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
   </ItemGroup>


### PR DESCRIPTION
Removed Moq as a dependency in all projects, addressing #17.
Turns out Moq wasn't used, which made the fix very simple.