### PR TITLE
chore/bump-nugets

### DIFF
--- a/src/PlanningPoker.Client/PlanningPoker.Client.csproj
+++ b/src/PlanningPoker.Client/PlanningPoker.Client.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Blazored.SessionStorage" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.8" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="6.0.8" />
+    <PackageReference Include="Blazored.SessionStorage" Version="2.4.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="6.0.21" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="6.0.21" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PlanningPoker.Engine.Core/PlanningPoker.Engine.Core.csproj
+++ b/src/PlanningPoker.Engine.Core/PlanningPoker.Engine.Core.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Reactive" Version="5.0.0" />
+    <PackageReference Include="System.Reactive" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PlanningPoker.Hub.Client/PlanningPoker.Hub.Client.csproj
+++ b/src/PlanningPoker.Hub.Client/PlanningPoker.Hub.Client.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client.Core" Version="6.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client.Core" Version="7.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/PlanningPoker.Server.Infrastructure/PlanningPoker.Server.Infrastructure.csproj
+++ b/src/PlanningPoker.Server.Infrastructure/PlanningPoker.Server.Infrastructure.csproj
@@ -5,7 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />

--- a/src/PlanningPoker.Server.Infrastructure/PlanningPoker.Server.Infrastructure.csproj
+++ b/src/PlanningPoker.Server.Infrastructure/PlanningPoker.Server.Infrastructure.csproj
@@ -6,8 +6,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="7.0.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
   </ItemGroup>
 

--- a/src/PlanningPoker.Server/PlanningPoker.Server.csproj
+++ b/src/PlanningPoker.Server/PlanningPoker.Server.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="6.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="6.0.21" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/PlanningPoker.FunctionalTests/PlanningPoker.FunctionalTests.csproj
+++ b/tests/PlanningPoker.FunctionalTests/PlanningPoker.FunctionalTests.csproj
@@ -7,11 +7,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoFixture" Version="4.17.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.8" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="AutoFixture" Version="4.18.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.21" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.1" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* Bumped NuGet packages.
* Removed deprecated package, Microsoft.AspNetCore.SignalR, as this is now part of ASP.Net Core shared framework.