### PR TITLE
feature/13/allow-non-number-in-mode

### DIFF
--- a/src/PlanningPoker.Client/Pages/Session/_sessionControlComponent.razor
+++ b/src/PlanningPoker.Client/Pages/Session/_sessionControlComponent.razor
@@ -97,13 +97,12 @@
         return HubClient.ShowVotes(Id);
     }
 
-    IEnumerable<decimal?> GetVoteMode()
+    IEnumerable<string?> GetVoteMode()
     {
         var sortedVoteGroups = Session?.Votes?
-            .Select(unparsedVote => DecimalParseOrNull(unparsedVote.Value))
+            .Select(unparsedVote => unparsedVote.Value)
             .Where(vote => vote != null)
             .GroupBy(parsedVote => parsedVote)
-            .Where(group => group.Key.HasValue)
             .OrderByDescending(group => group.Count());
 
         var highestVoteCount = sortedVoteGroups


### PR DESCRIPTION
Fixes #13 , by allowing non-numeric values to be used in mode calculation output. This allows ?, 👍 or anything else to be visible as the most voted value.