### PR TITLE
remotes/origin/bugfix/fix-flaky-tests

### DIFF
--- a/tests/PlanningPoker.FunctionalTests/PlanningPokerWebApplicationFactory.cs
+++ b/tests/PlanningPoker.FunctionalTests/PlanningPokerWebApplicationFactory.cs
@@ -34,6 +34,9 @@ namespace PlanningPoker.FunctionalTests
                 // that could be dependent on the outcome of these.
                 services.Remove(services.Single(s => s.ImplementationType == typeof(CleanupServerJob)));
                 services.AddSingleton<CleanupServerJob>();
+
+                services.Remove(services.Single(s => s.ImplementationType == typeof(ReportTelemetryJob)));
+                services.AddSingleton<ReportTelemetryJob>();
             });
         }
     }

--- a/tests/PlanningPoker.FunctionalTests/Tests/Hubs/PlanningPokerHubTestBuilder.cs
+++ b/tests/PlanningPoker.FunctionalTests/Tests/Hubs/PlanningPokerHubTestBuilder.cs
@@ -31,15 +31,7 @@ namespace PlanningPoker.FunctionalTests.Tests.Hubs
             var connection = new HubConnectionBuilder()
                 .WithUrl(hubUri, o =>
                 {
-                    o.SkipNegotiation = false;
-                    o.Transports = HttpTransportType.WebSockets;
-                    o.WebSocketFactory = (context, cancellationToken) =>
-                    {
-                        var webSocketClient = factory.Server.CreateWebSocketClient();
-                        var webSocket = webSocketClient.ConnectAsync(context.Uri, cancellationToken).GetAwaiter().GetResult();
-                        return ValueTask.FromResult(webSocket);
-                    };
-
+                    o.Transports = HttpTransportType.LongPolling;
                     o.HttpMessageHandlerFactory = _ => factory.Server.CreateHandler();
                 })
                 .Build();

--- a/tests/PlanningPoker.FunctionalTests/Tests/Hubs/PlanningPokerHubTests_ChangePlayerType.cs
+++ b/tests/PlanningPoker.FunctionalTests/Tests/Hubs/PlanningPokerHubTests_ChangePlayerType.cs
@@ -63,7 +63,7 @@ namespace PlanningPoker.FunctionalTests.Tests.Hubs
             await builder.HubClient.ChangePlayerType(serverId, desiredNewPlayerType);
 
             // Assert
-            await awaitResponse.WaitAsync(TimeSpan.FromSeconds(5));
+            await awaitResponse.WaitAsync(TimeoutProvider.GetDefaultTimeout());
             Assert.NotNull(updatedPlayer);
             Assert.Equal(desiredNewPlayerType, updatedPlayer.Type);
         }
@@ -106,7 +106,7 @@ namespace PlanningPoker.FunctionalTests.Tests.Hubs
             await builder.HubClient.ChangePlayerType(serverId, desiredNewPlayerType);
 
             // Assert
-            await awaitResponse.WaitAsync(TimeSpan.FromSeconds(5));
+            await awaitResponse.WaitAsync(TimeoutProvider.GetDefaultTimeout());
             Assert.NotNull(updatedPlayer);
             Assert.Equal(desiredNewPlayerType, updatedPlayer.Type);
         }

--- a/tests/PlanningPoker.FunctionalTests/Tests/Hubs/PlanningPokerHubTests_Clear.cs
+++ b/tests/PlanningPoker.FunctionalTests/Tests/Hubs/PlanningPokerHubTests_Clear.cs
@@ -58,14 +58,11 @@ namespace PlanningPoker.FunctionalTests.Tests.Hubs
             var hasVotes = true;
             var playerConnections = new List<IPlanningPokerHubClient>
             {
-                CreateBuilder().WithPlayer(serverId, out var player1).HubClient,
-                CreateBuilder().WithPlayer(serverId, out var player2).HubClient,
+                CreateBuilder().WithPlayer(serverId, out var player1).WithPlayerVoted(serverId, player1.Id, validVote).HubClient,
+                CreateBuilder().WithPlayer(serverId, out var player2).WithPlayerVoted(serverId, player2.Id, validVote).HubClient,
                 CreateBuilder().WithPlayer(serverId, out var player3).HubClient
             };
-
-            await playerConnections[0].Vote(serverId, player1.Id, validVote);
-            await playerConnections[1].Vote(serverId, player2.Id, validVote);
-
+            
             SemaphoreSlim awaitResponse = new SemaphoreSlim(0);
             playerConnections[2].OnSessionUpdated(viewModel =>
             {
@@ -77,7 +74,7 @@ namespace PlanningPoker.FunctionalTests.Tests.Hubs
             await playerConnections[2].ClearVotes(serverId);
 
             // Assert
-            await awaitResponse.WaitAsync(TimeSpan.FromSeconds(5));
+            await awaitResponse.WaitAsync(TimeoutProvider.GetDefaultTimeout());
             Assert.False(hasVotes);
         }
 
@@ -91,15 +88,11 @@ namespace PlanningPoker.FunctionalTests.Tests.Hubs
             var hasVotes = true;
             var playerConnections = new List<IPlanningPokerHubClient>
             {
-                CreateBuilder().WithPlayer(serverId, out var player1).HubClient,
-                CreateBuilder().WithPlayer(serverId, out var player2).HubClient,
-                CreateBuilder().WithPlayer(serverId, out var player3).HubClient
+                CreateBuilder().WithPlayer(serverId, out var player1).WithPlayerVoted(serverId, player1.Id, validVote).HubClient,
+                CreateBuilder().WithPlayer(serverId, out var player2).WithPlayerVoted(serverId, player2.Id, validVote).HubClient,
+                CreateBuilder().WithPlayer(serverId, out var player3).WithPlayerVoted(serverId, player3.Id, validVote).HubClient
             };
-
-            await playerConnections[0].Vote(serverId, player1.Id, validVote);
-            await playerConnections[1].Vote(serverId, player2.Id, validVote);
-            await playerConnections[2].Vote(serverId, player3.Id, validVote);
-
+            
             SemaphoreSlim awaitResponse = new SemaphoreSlim(0);
             playerConnections[2].OnSessionUpdated(viewModel =>
             {
@@ -111,7 +104,7 @@ namespace PlanningPoker.FunctionalTests.Tests.Hubs
             await playerConnections[2].ClearVotes(serverId);
 
             // Assert
-            await awaitResponse.WaitAsync(TimeSpan.FromSeconds(5));
+            await awaitResponse.WaitAsync(TimeoutProvider.GetDefaultTimeout());
             Assert.False(hasVotes);
         }
 
@@ -126,13 +119,11 @@ namespace PlanningPoker.FunctionalTests.Tests.Hubs
             var hasVotes = true;
             var playerConnections = new List<IPlanningPokerHubClient>
             {
-                CreateBuilder().WithPlayer(serverId, out var player1).HubClient,
+                CreateBuilder().WithPlayer(serverId, out var player1).WithPlayerVoted(serverId, player1.Id, validVote).HubClient,
                 CreateBuilder().WithPlayer(serverId, out var player2).HubClient,
                 CreateBuilder().WithPlayer(serverId, out var player3).HubClient
             };
-
-            await playerConnections[0].Vote(serverId, player1.Id, validVote);
-
+            
             SemaphoreSlim awaitResponse = new SemaphoreSlim(0);
             builder.HubClient.OnSessionUpdated(viewModel =>
             {
@@ -144,7 +135,7 @@ namespace PlanningPoker.FunctionalTests.Tests.Hubs
             await builder.HubClient.ClearVotes(serverId);
 
             // Assert
-            await awaitResponse.WaitAsync(TimeSpan.FromSeconds(5));
+            await awaitResponse.WaitAsync(TimeoutProvider.GetDefaultTimeout());
             Assert.False(hasVotes);
         }
     }

--- a/tests/PlanningPoker.FunctionalTests/Tests/Hubs/PlanningPokerHubTests_Kick.cs
+++ b/tests/PlanningPoker.FunctionalTests/Tests/Hubs/PlanningPokerHubTests_Kick.cs
@@ -73,8 +73,8 @@ namespace PlanningPoker.FunctionalTests.Tests.Hubs
             await player1Builder.HubClient.KickPlayer(serverId, player1.Id, player2.PublicId);
 
             // Assert
-            await awaitUpdateResponse.WaitAsync(TimeSpan.FromSeconds(5));
-            await awaitKickResponse.WaitAsync(TimeSpan.FromSeconds(5));
+            await awaitUpdateResponse.WaitAsync(TimeoutProvider.GetDefaultTimeout());
+            await awaitKickResponse.WaitAsync(TimeoutProvider.GetDefaultTimeout());
             Assert.Equal(1, playerCount);
             Assert.True(kickCommandInvoked);
             Assert.Equal(player2.PublicId, kickedPlayer.PublicId);

--- a/tests/PlanningPoker.FunctionalTests/Tests/Hubs/PlanningPokerHubTests_OnLogMessageReceived.cs
+++ b/tests/PlanningPoker.FunctionalTests/Tests/Hubs/PlanningPokerHubTests_OnLogMessageReceived.cs
@@ -35,7 +35,7 @@ namespace PlanningPoker.FunctionalTests.Tests.Hubs
             builder.WithVotesCleared(serverId);
 
             // Assert
-            await awaitResponse.WaitAsync(TimeSpan.FromSeconds(5));
+            await awaitResponse.WaitAsync(TimeoutProvider.GetDefaultTimeout());
             Assert.NotNull(logMessageReceived);
             Assert.Equal(player.Name, logMessageReceived.User);
             Assert.NotNull(logMessageReceived.Message);
@@ -62,7 +62,7 @@ namespace PlanningPoker.FunctionalTests.Tests.Hubs
             builder.WithPlayer(serverId, out var player);
 
             // Assert
-            await awaitResponse.WaitAsync(TimeSpan.FromSeconds(5));
+            await awaitResponse.WaitAsync(TimeoutProvider.GetDefaultTimeout());
             Assert.NotNull(logMessageReceived);
             Assert.Equal(player.Name, logMessageReceived.User);
             Assert.NotNull(logMessageReceived.Message);
@@ -92,7 +92,7 @@ namespace PlanningPoker.FunctionalTests.Tests.Hubs
             builder.WithPlayerKicked(serverId, player1.Id, player2.PublicId);
 
             // Assert
-            await awaitResponse.WaitAsync(TimeSpan.FromSeconds(5));
+            await awaitResponse.WaitAsync(TimeoutProvider.GetDefaultTimeout());
             Assert.NotNull(logMessageReceived);
             Assert.Equal(player1.Name, logMessageReceived.User);
             Assert.NotNull(logMessageReceived.Message);
@@ -122,7 +122,7 @@ namespace PlanningPoker.FunctionalTests.Tests.Hubs
             builder.WithVotesShown(serverId);
 
             // Assert
-            await awaitResponse.WaitAsync(TimeSpan.FromSeconds(5));
+            await awaitResponse.WaitAsync(TimeoutProvider.GetDefaultTimeout());
             Assert.NotNull(logMessageReceived);
             Assert.Equal(player.Name, logMessageReceived.User);
             Assert.NotNull(logMessageReceived.Message);
@@ -152,7 +152,7 @@ namespace PlanningPoker.FunctionalTests.Tests.Hubs
             builder.WithPlayerUnVoted(serverId, player.Id);
 
             // Assert
-            await awaitResponse.WaitAsync(TimeSpan.FromSeconds(5));
+            await awaitResponse.WaitAsync(TimeoutProvider.GetDefaultTimeout());
             Assert.NotNull(logMessageReceived);
             Assert.Equal(player.Name, logMessageReceived.User);
             Assert.NotNull(logMessageReceived.Message);
@@ -181,7 +181,7 @@ namespace PlanningPoker.FunctionalTests.Tests.Hubs
             builder.WithPlayerVoted(serverId, player.Id, validVote);
 
             // Assert
-            await awaitResponse.WaitAsync(TimeSpan.FromSeconds(5));
+            await awaitResponse.WaitAsync(TimeoutProvider.GetDefaultTimeout());
             Assert.NotNull(logMessageReceived);
             Assert.Equal(player.Name, logMessageReceived.User);
             Assert.NotNull(logMessageReceived.Message);

--- a/tests/PlanningPoker.FunctionalTests/Tests/Hubs/PlanningPokerHubTests_OnPlayerKicked.cs
+++ b/tests/PlanningPoker.FunctionalTests/Tests/Hubs/PlanningPokerHubTests_OnPlayerKicked.cs
@@ -39,7 +39,7 @@ namespace PlanningPoker.FunctionalTests.Tests.Hubs
             await player1Builder.HubClient.KickPlayer(serverId, player1.Id, player2.PublicId);
 
             // Assert
-            await awaitKickResponse.WaitAsync(TimeSpan.FromSeconds(5));
+            await awaitKickResponse.WaitAsync(TimeoutProvider.GetDefaultTimeout());
             Assert.True(kickCommandInvoked);
             Assert.Equal(player2.PublicId, kickedPlayer.PublicId);
             Assert.Null(kickedPlayer.Id);

--- a/tests/PlanningPoker.FunctionalTests/Tests/Hubs/PlanningPokerHubTests_OnSessionUpdated.cs
+++ b/tests/PlanningPoker.FunctionalTests/Tests/Hubs/PlanningPokerHubTests_OnSessionUpdated.cs
@@ -33,7 +33,7 @@ namespace PlanningPoker.FunctionalTests.Tests.Hubs
             builder.WithPlayer(serverId, out var player);
 
             // Assert
-            await awaitResponse.WaitAsync(TimeSpan.FromSeconds(5));
+            await awaitResponse.WaitAsync(TimeoutProvider.GetDefaultTimeout());
 
             Assert.NotNull(updatedSession);
             Assert.Equal(serverId, updatedSession.Id);
@@ -88,7 +88,7 @@ namespace PlanningPoker.FunctionalTests.Tests.Hubs
             builder.WithVotesShown(serverId);
 
             // Assert
-            await awaitResponse.WaitAsync(TimeSpan.FromSeconds(5));
+            await awaitResponse.WaitAsync(TimeoutProvider.GetDefaultTimeout());
 
             Assert.NotNull(updatedSession);
             Assert.Equal(serverId, updatedSession.Id);
@@ -146,7 +146,7 @@ namespace PlanningPoker.FunctionalTests.Tests.Hubs
             builder.WithVotesCleared(serverId);
 
             // Assert
-            await awaitResponse.WaitAsync(TimeSpan.FromSeconds(5));
+            await awaitResponse.WaitAsync(TimeoutProvider.GetDefaultTimeout());
 
             Assert.NotNull(updatedSession);
             Assert.Equal(serverId, updatedSession.Id);

--- a/tests/PlanningPoker.FunctionalTests/Tests/Hubs/PlanningPokerHubTests_OnVotesCleared.cs
+++ b/tests/PlanningPoker.FunctionalTests/Tests/Hubs/PlanningPokerHubTests_OnVotesCleared.cs
@@ -36,7 +36,7 @@ namespace PlanningPoker.FunctionalTests.Tests.Hubs
             builder.WithVotesCleared(serverId);
 
             // Assert
-            await awaitResponse.WaitAsync(TimeSpan.FromSeconds(5));
+            await awaitResponse.WaitAsync(TimeoutProvider.GetDefaultTimeout());
 
             Assert.True(votesClearedSent);
         }

--- a/tests/PlanningPoker.FunctionalTests/Tests/Hubs/PlanningPokerHubTests_Show.cs
+++ b/tests/PlanningPoker.FunctionalTests/Tests/Hubs/PlanningPokerHubTests_Show.cs
@@ -37,14 +37,11 @@ namespace PlanningPoker.FunctionalTests.Tests.Hubs
             var validVote = "1";
             var playerConnections = new List<IPlanningPokerHubClient>
             {
-                CreateBuilder().WithPlayer(serverId, out var player1).HubClient,
-                CreateBuilder().WithPlayer(serverId, out var player2).HubClient,
+                CreateBuilder().WithPlayer(serverId, out var player1).WithPlayerVoted(serverId, player1.Id, validVote).HubClient,
+                CreateBuilder().WithPlayer(serverId, out var player2).WithPlayerVoted(serverId, player2.Id, validVote).HubClient,
                 CreateBuilder().WithPlayer(serverId, out var player3).HubClient
             };
-
-            await playerConnections[0].Vote(serverId, player1.Id, validVote);
-            await playerConnections[1].Vote(serverId, player2.Id, validVote);
-
+            
             // Act
             var exceptionRecord = await Record.ExceptionAsync(() => playerConnections[2].ShowVotes(serverId));
 
@@ -63,13 +60,10 @@ namespace PlanningPoker.FunctionalTests.Tests.Hubs
             var actualVotes = new List<string>();
             var playerConnections = new List<IPlanningPokerHubClient>
             {
-                CreateBuilder().WithPlayer(serverId, out var player1).HubClient,
-                CreateBuilder().WithPlayer(serverId, out var player2).HubClient
+                CreateBuilder().WithPlayer(serverId, out var player1).WithPlayerVoted(serverId, player1.Id, validVote).HubClient,
+                CreateBuilder().WithPlayer(serverId, out var player2).WithPlayerVoted(serverId, player2.Id, validVote).HubClient
             };
-
-            await playerConnections[0].Vote(serverId, player1.Id, validVote);
-            await playerConnections[1].Vote(serverId, player2.Id, validVote);
-
+            
             SemaphoreSlim awaitResponse = new SemaphoreSlim(0);
             playerConnections[1].OnSessionUpdated(viewModel =>
             {
@@ -82,7 +76,7 @@ namespace PlanningPoker.FunctionalTests.Tests.Hubs
             await playerConnections[1].ShowVotes(serverId);
 
             // Assert
-            await awaitResponse.WaitAsync(TimeSpan.FromSeconds(5));
+            await awaitResponse.WaitAsync(TimeoutProvider.GetDefaultTimeout());
             Assert.Equal(validVote, actualVotes[0]);
             Assert.Equal(validVote, actualVotes[1]);
             Assert.True(isShown);

--- a/tests/PlanningPoker.FunctionalTests/Tests/Hubs/PlanningPokerHubTests_SleepPlayer.cs
+++ b/tests/PlanningPoker.FunctionalTests/Tests/Hubs/PlanningPokerHubTests_SleepPlayer.cs
@@ -62,7 +62,7 @@ namespace PlanningPoker.FunctionalTests.Tests.Hubs
             await disconnectingBuilder.HubClient.Disconnect();
 
             // Assert
-            await awaitResponse.WaitAsync(TimeSpan.FromSeconds(5));
+            await awaitResponse.WaitAsync(TimeoutProvider.GetDefaultTimeout());
             Assert.True(hasVoted);
         }
 
@@ -89,7 +89,7 @@ namespace PlanningPoker.FunctionalTests.Tests.Hubs
             await disconnectingBuilder.HubClient.Disconnect();
 
             // Assert
-            await awaitResponse.WaitAsync(TimeSpan.FromSeconds(5));
+            await awaitResponse.WaitAsync(TimeoutProvider.GetDefaultTimeout());
             Assert.True(canShow);
         }
 
@@ -115,7 +115,7 @@ namespace PlanningPoker.FunctionalTests.Tests.Hubs
             await disconnectingBuilder.HubClient.Disconnect();
 
             // Assert
-            await awaitResponse.WaitAsync(TimeSpan.FromSeconds(5));
+            await awaitResponse.WaitAsync(TimeoutProvider.GetDefaultTimeout());
             Assert.False(canClear);
         }
     }

--- a/tests/PlanningPoker.FunctionalTests/Tests/Hubs/PlanningPokerHubTests_UnVote.cs
+++ b/tests/PlanningPoker.FunctionalTests/Tests/Hubs/PlanningPokerHubTests_UnVote.cs
@@ -60,7 +60,7 @@ namespace PlanningPoker.FunctionalTests.Tests.Hubs
             await builder.HubClient.UnVote(serverId, player.Id);
 
             // Assert
-            await awaitResponse.WaitAsync(TimeSpan.FromSeconds(5));
+            await awaitResponse.WaitAsync(TimeoutProvider.GetDefaultTimeout());
             Assert.False(voteExists);
         }
 
@@ -85,7 +85,7 @@ namespace PlanningPoker.FunctionalTests.Tests.Hubs
             await builder.HubClient.UnVote(serverId, player.Id);
 
             // Assert
-            await awaitResponse.WaitAsync(TimeSpan.FromSeconds(5));
+            await awaitResponse.WaitAsync(TimeoutProvider.GetDefaultTimeout());
             Assert.False(voteExists);
         }
     }

--- a/tests/PlanningPoker.FunctionalTests/Tests/Hubs/PlanningPokerHubTests_Vote.cs
+++ b/tests/PlanningPoker.FunctionalTests/Tests/Hubs/PlanningPokerHubTests_Vote.cs
@@ -62,7 +62,7 @@ namespace PlanningPoker.FunctionalTests.Tests.Hubs
             await builder.HubClient.Vote(serverId, player.Id, validVote);
 
             // Assert
-            await awaitResponse.WaitAsync(TimeSpan.FromSeconds(5));
+            await awaitResponse.WaitAsync(TimeoutProvider.GetDefaultTimeout());
             Assert.Equal("?", actualVote);
         }
 
@@ -76,7 +76,7 @@ namespace PlanningPoker.FunctionalTests.Tests.Hubs
             var firstVote = "1";
             var secondVote = "21";
             string actualVote = null;
-            await builder.HubClient.Vote(serverId, player.Id, firstVote);
+            builder.WithPlayerVoted(serverId, player.Id, firstVote);
             SemaphoreSlim awaitResponse = new SemaphoreSlim(0);
             builder.HubClient.OnSessionUpdated(viewModel =>
             {
@@ -88,7 +88,7 @@ namespace PlanningPoker.FunctionalTests.Tests.Hubs
             await builder.HubClient.Vote(serverId, player.Id, secondVote);
 
             // Assert
-            await awaitResponse.WaitAsync(TimeSpan.FromSeconds(5));
+            await awaitResponse.WaitAsync(TimeoutProvider.GetDefaultTimeout());
             Assert.Equal("?", actualVote);
         }
 

--- a/tests/PlanningPoker.FunctionalTests/Tests/TimeoutProvider.cs
+++ b/tests/PlanningPoker.FunctionalTests/Tests/TimeoutProvider.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace PlanningPoker.FunctionalTests.Tests;
+
+public static class TimeoutProvider
+{
+    public static TimeSpan GetDefaultTimeout()
+    {
+        return TimeSpan.FromSeconds(5);
+    }
+}


### PR DESCRIPTION
Fixed flaky tests, which was caused by the OnSessionUpdate being vulnerable to receiving the session state from previous updates. It cannot guarantee the order which responses are being sent back. To fix this, the test must ensure that the session updated is the _right_ one. This is done by ensuring all previous commands are waiting for the session update that belongs to that specific action.

Additional minor fixes:
* Introduced shared default timeout provider, to keep the tests DRY.